### PR TITLE
Fixed zeek installation dependency name

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -3,4 +3,4 @@ description = Additional seen-triggers for Bro's intelligence framework.
 tags = intel, seen
 script_dir = scripts
 suggests =
-	bro/sethhall/domain-tld *
+  sethhall/domain-tld *


### PR DESCRIPTION
Bro was renamed to zeek and installation of plugins seems to fail due to the wrong name.